### PR TITLE
fix: use ABI-encoded string for IPFS CID in enter() calldata

### DIFF
--- a/.changeset/fix-publish-edit-encoding.md
+++ b/.changeset/fix-publish-edit-encoding.md
@@ -1,5 +1,0 @@
----
-"@geoprotocol/geo-sdk": minor
----
-
-Fix IPFS CID encoding in `publishEdit()` to use ABI-encoded string format, enabling the indexer to properly decode published edits.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @geoprotocol/geo-sdk
 
+## 0.6.0
+
+### Minor Changes
+
+- 75b0a34: Fix IPFS CID encoding in `publishEdit()` to use ABI-encoded string format, enabling the indexer to properly decode published edits.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoprotocol/geo-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Fix IPFS CID encoding in `publishEdit()` calldata to use ABI-encoded string format

## Problem

Published edits were not being indexed. The indexer expects the `data` parameter in `SpaceRegistry.enter()` to be an ABI-encoded string (with offset + length prefix), but the SDK was using `stringToHex(cid)` which produces raw hex bytes.

## Solution

Changed from:
```typescript
stringToHex(cid)
```

To:
```typescript
encodeAbiParameters([{ type: 'string' }], [cid])
```

This matches the encoding used by geo-cli and produces calldata that the indexer can properly decode to extract the IPFS CID.