### PR TITLE
fix: validate initialTopicId as UUID in DAO space creation

### DIFF
--- a/src/encodings/get-create-dao-space-calldata.test.ts
+++ b/src/encodings/get-create-dao-space-calldata.test.ts
@@ -235,4 +235,53 @@ describe('getCreateDaoSpaceCalldata', () => {
     };
     expect(() => getCreateDaoSpaceCalldata(args)).toThrow('IPFS URI contains an invalid CID format');
   });
+
+  it('should accept a valid dashless UUID as initialTopicId', () => {
+    const args = {
+      ...validArgs,
+      initialTopicId: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+    };
+    const calldata = getCreateDaoSpaceCalldata(args);
+    expect(calldata).toBeTypeOf('string');
+    expect(calldata.startsWith('0x')).toBe(true);
+  });
+
+  it('should accept a valid dashed UUID as initialTopicId', () => {
+    const args = {
+      ...validArgs,
+      initialTopicId: 'a1b2c3d4-e5f6-a7b8-c9d0-e1f2a3b4c5d6',
+    };
+    const calldata = getCreateDaoSpaceCalldata(args);
+    expect(calldata).toBeTypeOf('string');
+    expect(calldata.startsWith('0x')).toBe(true);
+  });
+
+  it('should throw for invalid initialTopicId', () => {
+    const args = {
+      ...validArgs,
+      initialTopicId: 'not-a-uuid',
+    };
+    expect(() => getCreateDaoSpaceCalldata(args)).toThrow(
+      'initialTopicId must be a valid UUID (32 hex chars or 8-4-4-4-12 dashed format)',
+    );
+  });
+
+  it('should throw for initialTopicId that is too short', () => {
+    const args = {
+      ...validArgs,
+      initialTopicId: 'a1b2c3d4',
+    };
+    expect(() => getCreateDaoSpaceCalldata(args)).toThrow(
+      'initialTopicId must be a valid UUID (32 hex chars or 8-4-4-4-12 dashed format)',
+    );
+  });
+
+  it('should generate different calldata with and without initialTopicId', () => {
+    const calldataWithout = getCreateDaoSpaceCalldata(validArgs);
+    const calldataWith = getCreateDaoSpaceCalldata({
+      ...validArgs,
+      initialTopicId: 'a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6',
+    });
+    expect(calldataWithout).not.toBe(calldataWith);
+  });
 });

--- a/src/encodings/get-create-dao-space-calldata.ts
+++ b/src/encodings/get-create-dao-space-calldata.ts
@@ -1,6 +1,7 @@
 import { encodeAbiParameters, encodeFunctionData } from 'viem';
 
 import { DaoSpaceFactoryAbi } from '../abis/index.js';
+import { isValid as isValidUuid } from '../id.js';
 
 // Contract constants from DAOSpace.sol
 /**
@@ -240,6 +241,9 @@ export function getCreateDaoSpaceCalldata(args: CreateDaoSpaceCalldataParams): `
   // Convert UUID to bytes16 hex if provided
   let initialTopicId: `0x${string}` = '0x00000000000000000000000000000000';
   if (args.initialTopicId) {
+    if (!isValidUuid(args.initialTopicId)) {
+      throw new Error('initialTopicId must be a valid UUID (32 hex chars or 8-4-4-4-12 dashed format)');
+    }
     // Remove dashes from UUID and add 0x prefix
     initialTopicId = `0x${args.initialTopicId.replace(/-/g, '')}`;
   }


### PR DESCRIPTION
## Summary

- Add UUID validation to the `initialTopicId` parameter in `getCreateDaoSpaceCalldata`, reusing the existing `isValid` check from `id.ts`
- Previously, any arbitrary string was silently accepted and converted to malformed bytes16 calldata
- Add tests covering valid UUIDs (dashed and dashless), invalid strings, and too-short input