### PR TITLE
fix: correct author JSDoc from 'Person Entity ID' to 'personal space ID'

### DIFF
--- a/src/dao-space/create-space.ts
+++ b/src/dao-space/create-space.ts
@@ -1,12 +1,12 @@
-import type { Op } from '@geoprotocol/grc-20';
+import type { Op } from "@geoprotocol/grc-20";
 
-import { TESTNET } from '../../contracts.js';
-import { SPACE_TYPE } from '../core/ids/system.js';
-import { getCreateDaoSpaceCalldata } from '../encodings/index.js';
-import { createEntity } from '../graph/create-entity.js';
-import * as IdUtils from '../id-utils.js';
-import { publishEdit } from '../ipfs.js';
-import type { CreateSpaceParams, CreateSpaceResult } from './types.js';
+import { TESTNET } from "../../contracts.js";
+import { SPACE_TYPE } from "../core/ids/system.js";
+import { getCreateDaoSpaceCalldata } from "../encodings/index.js";
+import { createEntity } from "../graph/create-entity.js";
+import * as IdUtils from "../id-utils.js";
+import { publishEdit } from "../ipfs.js";
+import type { CreateSpaceParams, CreateSpaceResult } from "./types.js";
 
 /**
  * Get the target address and calldata for creating a DAO space.
@@ -33,7 +33,7 @@ import type { CreateSpaceParams, CreateSpaceResult } from './types.js';
  *     durationInDays: 7,                // 7 day voting period
  *   },
  *   initialEditorSpaceIds: ['0x01234567890abcdef01234567890abcd'],
- *   author: 'your-person-entity-id',
+ *   author: 'your-personal-space-id',
  * });
  *
  * // Using viem
@@ -43,8 +43,10 @@ import type { CreateSpaceParams, CreateSpaceResult } from './types.js';
  * });
  * ```
  */
-export async function createSpace(params: CreateSpaceParams): Promise<CreateSpaceResult> {
-  const { name, author, ops: additionalOps = [], network = 'TESTNET' } = params;
+export async function createSpace(
+  params: CreateSpaceParams,
+): Promise<CreateSpaceResult> {
+  const { name, author, ops: additionalOps = [], network = "TESTNET" } = params;
 
   // Generate a space entity ID
   const spaceEntityId = IdUtils.generate();

--- a/src/dao-space/types.ts
+++ b/src/dao-space/types.ts
@@ -1,7 +1,7 @@
-import type { Op } from '@geoprotocol/grc-20';
-import type { VotingSettingsInput } from '../encodings/get-create-dao-space-calldata.js';
-import type { Id } from '../id.js';
-import type { Network } from '../types.js';
+import type { Op } from "@geoprotocol/grc-20";
+import type { VotingSettingsInput } from "../encodings/get-create-dao-space-calldata.js";
+import type { Id } from "../id.js";
+import type { Network } from "../types.js";
 
 export type CreateSpaceParams = {
   /** Name of the DAO space */
@@ -12,7 +12,7 @@ export type CreateSpaceParams = {
   initialEditorSpaceIds: `0x${string}`[];
   /** Space IDs of initial members (can be empty). Must be bytes16 hex strings. */
   initialMemberSpaceIds?: `0x${string}`[];
-  /** The author's Person Entity ID (UUID). */
+  /** The author's personal space ID (UUID). */
   author: Id | string;
   /** Additional ops to include in the initial edit (optional) */
   ops?: Op[];
@@ -36,14 +36,14 @@ export type CreateSpaceResult = {
  * - SLOW: Standard voting requiring percentage threshold
  * - FAST: Fast-path voting requiring flat threshold (for valid fast-path actions)
  */
-export type VotingMode = 'SLOW' | 'FAST';
+export type VotingMode = "SLOW" | "FAST";
 
 export type ProposeEditParams = {
   /** Name of the edit (used for IPFS metadata) */
   name: string;
   /** The ops to include in the edit */
   ops: Op[];
-  /** The author's Person Entity ID (UUID). */
+  /** The author's personal space ID (UUID). */
   author: Id | string;
   /**
    * The DAO space contract address.

--- a/src/personal-space/publish-edit.ts
+++ b/src/personal-space/publish-edit.ts
@@ -1,12 +1,12 @@
-import { encodeAbiParameters, encodeFunctionData, toHex } from 'viem';
-import { TESTNET } from '../../contracts.js';
-import { SpaceRegistryAbi } from '../abis/index.js';
-import { isValid } from '../id.js';
-import { toBytes } from '../id-utils.js';
-import { UUID_DASHLESS_REGEX } from '../internal/uuid.js';
-import * as Ipfs from '../ipfs.js';
-import { EDITS_PUBLISHED, EMPTY_SIGNATURE, EMPTY_TOPIC } from './constants.js';
-import type { PublishEditParams, PublishEditResult } from './types.js';
+import { encodeAbiParameters, encodeFunctionData, toHex } from "viem";
+import { TESTNET } from "../../contracts.js";
+import { SpaceRegistryAbi } from "../abis/index.js";
+import { isValid } from "../id.js";
+import { toBytes } from "../id-utils.js";
+import { UUID_DASHLESS_REGEX } from "../internal/uuid.js";
+import * as Ipfs from "../ipfs.js";
+import { EDITS_PUBLISHED, EMPTY_SIGNATURE, EMPTY_TOPIC } from "./constants.js";
+import type { PublishEditParams, PublishEditResult } from "./types.js";
 
 /**
  * Converts a spaceId to bytes16 hex format.
@@ -25,7 +25,9 @@ function spaceIdToBytes16(spaceId: string): `0x${string}` {
     return toHex(bytes);
   }
 
-  throw new Error(`Invalid spaceId: "${spaceId}". Expected a valid UUID or 32-character hex string.`);
+  throw new Error(
+    `Invalid spaceId: "${spaceId}". Expected a valid UUID or 32-character hex string.`,
+  );
 }
 
 /**
@@ -48,14 +50,16 @@ function spaceIdToBytes16(spaceId: string): `0x${string}` {
  *   name: 'Add entity',
  *   spaceId: 'your-space-id',
  *   ops,
- *   author: 'your-person-entity-id',
+ *   author: 'your-personal-space-id',
  * });
  *
  * await walletClient.sendTransaction({ to, data: calldata });
  * ```
  */
-export async function publishEdit(params: PublishEditParams): Promise<PublishEditResult> {
-  const { name, spaceId, ops, author, network = 'TESTNET' } = params;
+export async function publishEdit(
+  params: PublishEditParams,
+): Promise<PublishEditResult> {
+  const { name, spaceId, ops, author, network = "TESTNET" } = params;
 
   const spaceIdBytes16 = spaceIdToBytes16(spaceId);
 
@@ -68,12 +72,19 @@ export async function publishEdit(params: PublishEditParams): Promise<PublishEdi
 
   // Encode the IPFS URI as ABI-encoded string (offset + length + data)
   // The indexer expects this format to extract the CID
-  const encodedCid = encodeAbiParameters([{ type: 'string' }], [cid]);
+  const encodedCid = encodeAbiParameters([{ type: "string" }], [cid]);
 
   const calldata = encodeFunctionData({
     abi: SpaceRegistryAbi,
-    functionName: 'enter',
-    args: [spaceIdBytes16, spaceIdBytes16, EDITS_PUBLISHED, EMPTY_TOPIC, encodedCid, EMPTY_SIGNATURE],
+    functionName: "enter",
+    args: [
+      spaceIdBytes16,
+      spaceIdBytes16,
+      EDITS_PUBLISHED,
+      EMPTY_TOPIC,
+      encodedCid,
+      EMPTY_SIGNATURE,
+    ],
   });
 
   return {

--- a/src/personal-space/types.ts
+++ b/src/personal-space/types.ts
@@ -1,6 +1,6 @@
-import type { Op } from '@geoprotocol/grc-20';
-import type { Id } from '../id.js';
-import type { Network } from '../types.js';
+import type { Op } from "@geoprotocol/grc-20";
+import type { Id } from "../id.js";
+import type { Network } from "../types.js";
 
 export type CreateSpaceResult = {
   to: `0x${string}`;
@@ -11,7 +11,7 @@ export type PublishEditParams = {
   name: string;
   spaceId: Id | string;
   ops: Op[];
-  /** The author's Person Entity ID (UUID). */
+  /** The author's personal space ID (UUID). */
   author: Id | string;
   network?: Network;
 };


### PR DESCRIPTION
## Summary

- Updates stale JSDoc across the SDK that described the `author` field as "Person Entity ID" when it should be "personal space ID"
- All tests (e.g. `TEST_AUTHOR_SPACE_ID`) and integration tests (`author: spaceId`, `author: personalSpaceId`) already pass the space ID — the docs were just out of date
- Updates code examples in JSDoc from `'your-person-entity-id'` to `'your-personal-space-id'`

**Files changed:**
- `src/ipfs.ts` — type definition + code example
- `src/personal-space/types.ts` — `PublishEditParams.author`
- `src/personal-space/publish-edit.ts` — code example
- `src/dao-space/types.ts` — `CreateSpaceParams.author` + `ProposeEditParams.author`
- `src/dao-space/propose-edit.ts` — code example
- `src/dao-space/create-space.ts` — code example