### PR TITLE
fix(ipfs): enforce 10MB size limit on edits before upload

### DIFF
--- a/.changeset/edit-size-limit.md
+++ b/.changeset/edit-size-limit.md
@@ -1,0 +1,5 @@
+---
+"@geoprotocol/geo-sdk": minor
+---
+
+Throw an error when an edit exceeds the 10MB size limit before uploading to IPFS.

--- a/src/ipfs.ts
+++ b/src/ipfs.ts
@@ -75,6 +75,13 @@ export async function publishEdit(args: PublishEditProposalParams): Promise<Publ
   // Encode to binary format
   const binary = encodeEdit(grcEdit);
 
+  const MAX_EDIT_SIZE = 10 * 1024 * 1024; // 10MB
+  if (binary.byteLength > MAX_EDIT_SIZE) {
+    throw new Error(
+      `Edit size (${(binary.byteLength / 1024 / 1024).toFixed(2)}MB) exceeds the ${MAX_EDIT_SIZE / 1024 / 1024}MB limit. Reduce the number of ops or split into multiple edits.`,
+    );
+  }
+
   // Create a copy to ensure we have a regular ArrayBuffer for Blob compatibility
   const binaryArray = new Uint8Array(binary);
   const blob = new Blob([binaryArray], { type: 'application/octet-stream' });


### PR DESCRIPTION
Closes #51 