### PR TITLE
feat(proposalReview): add optional content field

### DIFF
--- a/.changeset/add-proposal-review-content.md
+++ b/.changeset/add-proposal-review-content.md
@@ -1,0 +1,5 @@
+---
+"@geoprotocol/geo-sdk": patch
+---
+
+Add optional `content` parameter to `Graph.createProposalReview` and `Graph.updateProposalReview`.

--- a/src/graph/create-proposal-review.test.ts
+++ b/src/graph/create-proposal-review.test.ts
@@ -5,6 +5,7 @@ import {
   BOUNTY_REVIEW_TYPE,
   COMPLETENESS_RATING_PROPERTY,
   EFFORT_RATING_PROPERTY,
+  MARKDOWN_CONTENT,
   NAME_PROPERTY,
   PASS_PROPERTY,
   PROPOSALS_PROPERTY,
@@ -182,6 +183,64 @@ describe('createProposalReview', () => {
     expect(completenessValue).toBeDefined();
     if (completenessValue?.value.type === 'float') {
       expect(completenessValue?.value.value).toBe(0);
+    }
+  });
+
+  it('includes content value when content is provided', () => {
+    const { ops } = createProposalReview({
+      proposal: { id: proposalId, name: proposalName },
+      pass: true,
+      content: 'Detailed review notes',
+    });
+
+    const entityOp = ops[0] as CreateEntity;
+    const contentValue = entityOp.values.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeDefined();
+    expect(contentValue?.value.type).toBe('text');
+    if (contentValue?.value.type === 'text') {
+      expect(contentValue?.value.value).toBe('Detailed review notes');
+    }
+  });
+
+  it('does not include content value when content is omitted', () => {
+    const { ops } = createProposalReview({
+      proposal: { id: proposalId, name: proposalName },
+      pass: true,
+    });
+
+    const entityOp = ops[0] as CreateEntity;
+    const contentValue = entityOp.values.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeUndefined();
+  });
+
+  it('does not include content value when content is an empty string', () => {
+    const { ops } = createProposalReview({
+      proposal: { id: proposalId, name: proposalName },
+      pass: true,
+      content: '',
+    });
+
+    const entityOp = ops[0] as CreateEntity;
+    const contentValue = entityOp.values.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeUndefined();
+  });
+
+  it('includes content value alongside ratings', () => {
+    const { ops } = createProposalReview({
+      proposal: { id: proposalId, name: proposalName },
+      pass: false,
+      content: 'Notes with ratings',
+      completeness: 0.8,
+      accuracy: 1,
+      skill: 0.6,
+      effort: 0.4,
+    });
+
+    const entityOp = ops[0] as CreateEntity;
+    const contentValue = entityOp.values.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeDefined();
+    if (contentValue?.value.type === 'text') {
+      expect(contentValue?.value.value).toBe('Notes with ratings');
     }
   });
 

--- a/src/graph/create-proposal-review.ts
+++ b/src/graph/create-proposal-review.ts
@@ -3,6 +3,7 @@ import {
   BOUNTY_REVIEW_TYPE,
   COMPLETENESS_RATING_PROPERTY,
   EFFORT_RATING_PROPERTY,
+  MARKDOWN_CONTENT,
   PASS_PROPERTY,
   PROPOSALS_PROPERTY,
   SKILL_RATING_PROPERTY,
@@ -21,16 +22,18 @@ import { createEntity } from './create-entity.js';
  * ```ts
  * import { Graph } from '@geoprotocol/geo-sdk';
  *
- * // Low-difficulty bounty review (pass only)
+ * // Low-difficulty bounty review (pass + optional content)
  * const { id, ops } = Graph.createProposalReview({
  *   proposal: { id: proposalId, name: 'Proposal name' },
  *   pass: true,
+ *   content: 'Review notes', // optional, plain text or markdown
  * });
  *
- * // Medium/hard bounty review (with ratings)
+ * // Medium/hard bounty review (with ratings + optional content)
  * const { id, ops } = Graph.createProposalReview({
  *   proposal: { id: proposalId, name: 'Proposal name' },
  *   pass: true,
+ *   content: 'Review notes', // optional, plain text or markdown
  *   completeness: 0.8,
  *   accuracy: 1,
  *   skill: 0.6,
@@ -54,6 +57,14 @@ export const createProposalReview = (params: CreateProposalReviewParams): Create
       value: params.pass,
     },
   ];
+
+  if (params.content) {
+    values.push({
+      property: MARKDOWN_CONTENT,
+      type: 'text',
+      value: params.content,
+    });
+  }
 
   if ('completeness' in params) {
     values.push(

--- a/src/graph/update-proposal-review.test.ts
+++ b/src/graph/update-proposal-review.test.ts
@@ -4,6 +4,7 @@ import {
   ACCURACY_RATING_PROPERTY,
   COMPLETENESS_RATING_PROPERTY,
   EFFORT_RATING_PROPERTY,
+  MARKDOWN_CONTENT,
   NAME_PROPERTY,
   PASS_PROPERTY,
   SKILL_RATING_PROPERTY,
@@ -110,6 +111,64 @@ describe('updateProposalReview', () => {
     expect(effortValue?.value.type).toBe('float');
     if (effortValue?.value.type === 'float') {
       expect(effortValue?.value.value).toBe(0.4);
+    }
+  });
+
+  it('includes content value when content is provided', () => {
+    const { ops } = updateProposalReview({
+      proposalReviewId: reviewId,
+      pass: true,
+      content: 'Updated notes',
+    });
+
+    const op = ops[0] as UpdateEntity;
+    const contentValue = op.set.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeDefined();
+    expect(contentValue?.value.type).toBe('text');
+    if (contentValue?.value.type === 'text') {
+      expect(contentValue?.value.value).toBe('Updated notes');
+    }
+  });
+
+  it('does not include content value when content is omitted', () => {
+    const { ops } = updateProposalReview({
+      proposalReviewId: reviewId,
+      pass: true,
+    });
+
+    const op = ops[0] as UpdateEntity;
+    const contentValue = op.set.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeUndefined();
+  });
+
+  it('does not include content value when content is an empty string', () => {
+    const { ops } = updateProposalReview({
+      proposalReviewId: reviewId,
+      pass: true,
+      content: '',
+    });
+
+    const op = ops[0] as UpdateEntity;
+    const contentValue = op.set.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeUndefined();
+  });
+
+  it('includes content value alongside ratings', () => {
+    const { ops } = updateProposalReview({
+      proposalReviewId: reviewId,
+      pass: false,
+      content: 'Notes with ratings',
+      completeness: 0.8,
+      accuracy: 1,
+      skill: 0.6,
+      effort: 0.4,
+    });
+
+    const op = ops[0] as UpdateEntity;
+    const contentValue = op.set.find(v => v.property.every((b, i) => b === toGrcId(MARKDOWN_CONTENT)[i]));
+    expect(contentValue).toBeDefined();
+    if (contentValue?.value.type === 'text') {
+      expect(contentValue?.value.value).toBe('Notes with ratings');
     }
   });
 

--- a/src/graph/update-proposal-review.ts
+++ b/src/graph/update-proposal-review.ts
@@ -2,6 +2,7 @@ import {
   ACCURACY_RATING_PROPERTY,
   COMPLETENESS_RATING_PROPERTY,
   EFFORT_RATING_PROPERTY,
+  MARKDOWN_CONTENT,
   PASS_PROPERTY,
   SKILL_RATING_PROPERTY,
 } from '../core/ids/system.js';
@@ -17,16 +18,18 @@ import { updateEntity } from './update-entity.js';
  * ```ts
  * import { Graph } from '@geoprotocol/geo-sdk';
  *
- * // Update pass only (low difficulty)
+ * // Update pass + optional content (low difficulty)
  * const { id, ops } = Graph.updateProposalReview({
  *   proposalReviewId: reviewId,
  *   pass: false,
+ *   content: 'Updated review notes', // optional, plain text or markdown
  * });
  *
- * // Update with ratings (medium/hard difficulty)
+ * // Update with ratings + optional content (medium/hard difficulty)
  * const { id, ops } = Graph.updateProposalReview({
  *   proposalReviewId: reviewId,
  *   pass: true,
+ *   content: 'Updated review notes', // optional, plain text or markdown
  *   completeness: 0.8,
  *   accuracy: 1,
  *   skill: 0.6,
@@ -47,6 +50,14 @@ export const updateProposalReview = (params: UpdateProposalReviewParams): Create
       value: params.pass,
     },
   ];
+
+  if (params.content) {
+    values.push({
+      property: MARKDOWN_CONTENT,
+      type: 'text',
+      value: params.content,
+    });
+  }
 
   if ('completeness' in params) {
     values.push(

--- a/src/types.ts
+++ b/src/types.ts
@@ -226,11 +226,13 @@ export type CreateProposalReviewParams =
       id?: Id | string;
       proposal: { id: Id | string; name: string };
       pass: boolean;
+      content?: string;
     }
   | {
       id?: Id | string;
       proposal: { id: Id | string; name: string };
       pass: boolean;
+      content?: string;
       completeness: StarRating;
       accuracy: StarRating;
       skill: StarRating;
@@ -241,10 +243,12 @@ export type UpdateProposalReviewParams =
   | {
       proposalReviewId: Id | string;
       pass: boolean;
+      content?: string;
     }
   | {
       proposalReviewId: Id | string;
       pass: boolean;
+      content?: string;
       completeness: StarRating;
       accuracy: StarRating;
       skill: StarRating;


### PR DESCRIPTION
Closes #76 
## Summary
- Add optional `content` field to `Graph.createProposalReview` and `Graph.updateProposalReview`
- Stored as `MARKDOWN_CONTENT` text value when provided
- Empty strings are treated as no content
