### PR TITLE
fix(ranks): accept non-RFC 4122 ids in vote duplicate check

### DIFF
--- a/.changeset/brave-otters-sing.md
+++ b/.changeset/brave-otters-sing.md
@@ -1,0 +1,5 @@
+---
+"@geoprotocol/geo-sdk": patch
+---
+
+Fix `createRank`/`updateRank` throwing `TypeError: Invalid UUID` for valid Geo IDs that are not RFC 4122 UUIDs. The vote duplicate check now normalizes IDs as plain hex instead of parsing them as UUIDs.

--- a/src/ranks/create-rank.test.ts
+++ b/src/ranks/create-rank.test.ts
@@ -467,6 +467,33 @@ describe('createRank', () => {
       ).toThrow(`Duplicate (entityId, spaceId) in votes: "${movie1Id}:${spaceId}".`);
     });
 
+    it('accepts ids that are not RFC 4122 UUIDs (arbitrary 16-byte hex)', () => {
+      // Geo space IDs are arbitrary 16-byte values; this one has non-spec
+      // version ('f') and variant ('f') nibbles.
+      const nonRfcSpaceId = Id('73a82967cb12f604f9589ac4bc8024cb');
+      expect(() =>
+        createRank({
+          name: 'My Rank',
+          rankType: 'WEIGHTED',
+          votes: [{ entityId: movie1Id, spaceId: nonRfcSpaceId, value: 1 }],
+        }),
+      ).not.toThrow();
+    });
+
+    it('detects duplicates for ids that are not RFC 4122 UUIDs', () => {
+      const nonRfcSpaceId = Id('73a82967cb12f604f9589ac4bc8024cb');
+      expect(() =>
+        createRank({
+          name: 'My Rank',
+          rankType: 'ORDINAL',
+          votes: [
+            { entityId: movie1Id, spaceId: nonRfcSpaceId },
+            { entityId: movie1Id, spaceId: nonRfcSpaceId },
+          ],
+        }),
+      ).toThrow('Duplicate (entityId, spaceId) in votes');
+    });
+
     it('detects duplicates across dashed and dashless forms of the same id', () => {
       const dashless = String(movie1Id).replaceAll('-', '');
       expect(() =>

--- a/src/ranks/update-rank.test.ts
+++ b/src/ranks/update-rank.test.ts
@@ -142,4 +142,18 @@ describe('updateRank', () => {
       }),
     ).toThrow(`Duplicate (entityId, spaceId) in votes: "${movie1Id}:${spaceId}".`);
   });
+
+  it('accepts ids that are not RFC 4122 UUIDs (arbitrary 16-byte hex)', () => {
+    // Geo space IDs are arbitrary 16-byte values; this one has non-spec
+    // version ('f') and variant ('f') nibbles.
+    const nonRfcSpaceId = Id('73a82967cb12f604f9589ac4bc8024cb');
+    expect(() =>
+      updateRank({
+        rankId,
+        rankType: 'WEIGHTED',
+        votes: [{ entityId: movie1Id, spaceId: nonRfcSpaceId, value: 1 }],
+        existingVotes: [{ relationId: existingRel1, voteEntityId: existingVote1 }],
+      }),
+    ).not.toThrow();
+  });
 });

--- a/src/ranks/vote-ops.ts
+++ b/src/ranks/vote-ops.ts
@@ -12,8 +12,12 @@ import {
   VOTE_WEIGHTED_VALUE_PROPERTY,
 } from '../core/ids/system.js';
 import type { Id } from '../id.js';
-import { assertValid, fromBytes, generate, toBytes, toGrcId } from '../id-utils.js';
+import { assertValid, generate, toGrcId } from '../id-utils.js';
 import type { RankType, Vote, VoteWeighted } from './types.js';
+
+function normalizeIdKey(id: string): string {
+  return id.replaceAll('-', '').toLowerCase();
+}
 
 /**
  * Validates every vote and enforces `(entityId, spaceId)` uniqueness within a
@@ -46,7 +50,7 @@ export function validateVotes(votes: Vote[], rankType: RankType, context: string
 
     // Key on the canonical (lowercase, dashless) form so a dashed and a dashless
     // — or differently-cased — spelling of the same UUID still collide.
-    const key = `${fromBytes(toBytes(vote.entityId))}:${fromBytes(toBytes(vote.spaceId))}`;
+    const key = `${normalizeIdKey(vote.entityId)}:${normalizeIdKey(vote.spaceId)}`;
     if (seen.has(key)) {
       throw new Error(
         `Duplicate (entityId, spaceId) in votes: "${String(vote.entityId)}:${String(vote.spaceId)}". Each entity can only be voted once per space perspective in a rank.`,


### PR DESCRIPTION
## Problem

`createRank` and `updateRank` throw `TypeError: Invalid UUID` for valid Geo IDs that are not spec-compliant RFC 4122 UUIDs (present in 0.19.3).

The `(entityId, spaceId)` uniqueness key in `validateVotes` normalized each ID by round-tripping it through `uuid.parse`, which requires a version nibble of 1–5 and a variant nibble of 8/9/a/b. Geo IDs are arbitrary 16-byte values — e.g. the reported space ID `73a82967cb12f604f9589ac4bc8024cb` has `f` in both positions — so the SDK's own `assertValid` passed the ID and then the key construction threw. Roughly 7 out of 8 random 16-byte IDs hit this.

The op-building path was unaffected: `toGrcId` goes through grc-20's `parseId`, which accepts these IDs. Only the duplicate-check normalization was broken.

## Fix

Build the dedup key from the lowercased, dash-stripped hex string instead of parsing as a UUID. This preserves the documented intent (dashed/dashless and differently-cased spellings of the same ID still collide) without imposing RFC 4122 validity.

## Tests

- `createRank` / `updateRank` regression tests with the reported non-RFC space ID
- Duplicate detection still works for non-RFC IDs
- Full suite passes (1077 tests)