### PR TITLE
feat: add system type ids

### DIFF
--- a/.changeset/system-type-ids.md
+++ b/.changeset/system-type-ids.md
@@ -1,0 +1,5 @@
+---
+"@geoprotocol/geo-sdk": patch
+---
+
+Add exported system type IDs for System, Space, Proposal, EOA Space, and DAO Space.

--- a/src/core/ids/system.ts
+++ b/src/core/ids/system.ts
@@ -3,11 +3,11 @@ import { Id } from '../../id.js';
 export const ENTITY_ID_PROPERTY = Id('1a1fff3357824c3393c7c3a5f3592b60');
 
 /** System types */
-export const SYSTEM_TYPE_ID = Id('2ff7ea098b9e50bc9be78a0cafa268d0');
-export const SPACE_TYPE_ID = Id('f4ce7263ed1456c5aafe8b74428ce812');
-export const PROPOSAL_TYPE_ID = Id('1cb9d5bac73052a7bc731f2c3ff5a330');
-export const EOA_SPACE_TYPE_ID = Id('09d28123178f5828b85a81979389c746');
-export const DAO_SPACE_TYPE_ID = Id('afd76215db115cba81b9e7f77f865805');
+export const SYSTEM_TYPE = Id('2ff7ea098b9e50bc9be78a0cafa268d0');
+export const SYSTEM_SPACE_TYPE = Id('f4ce7263ed1456c5aafe8b74428ce812');
+export const PROPOSAL_TYPE = Id('1cb9d5bac73052a7bc731f2c3ff5a330');
+export const EOA_SPACE_TYPE = Id('09d28123178f5828b85a81979389c746');
+export const DAO_SPACE_TYPE = Id('afd76215db115cba81b9e7f77f865805');
 
 export const PROPERTY = Id('808a04ceb21c4d888ad12e240613e5ca');
 export const SCHEMA_TYPE = Id('e7d737c536764c609fa16aa64a8c90ad');

--- a/src/core/ids/system.ts
+++ b/src/core/ids/system.ts
@@ -2,6 +2,13 @@ import { Id } from '../../id.js';
 
 export const ENTITY_ID_PROPERTY = Id('1a1fff3357824c3393c7c3a5f3592b60');
 
+/** System types */
+export const SYSTEM_TYPE_ID = Id('2ff7ea098b9e50bc9be78a0cafa268d0');
+export const SPACE_TYPE_ID = Id('f4ce7263ed1456c5aafe8b74428ce812');
+export const PROPOSAL_TYPE_ID = Id('1cb9d5bac73052a7bc731f2c3ff5a330');
+export const EOA_SPACE_TYPE_ID = Id('09d28123178f5828b85a81979389c746');
+export const DAO_SPACE_TYPE_ID = Id('afd76215db115cba81b9e7f77f865805');
+
 export const PROPERTY = Id('808a04ceb21c4d888ad12e240613e5ca');
 export const SCHEMA_TYPE = Id('e7d737c536764c609fa16aa64a8c90ad');
 export const PROPERTIES = Id('01412f8381894ab1836565c7fd358cc1');

--- a/src/system-ids.test.ts
+++ b/src/system-ids.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { SystemIds } from './system-ids.js';
+
+describe('SystemIds', () => {
+  it('exports system type IDs', () => {
+    expect(SystemIds.SYSTEM_TYPE_ID).toBe('2ff7ea098b9e50bc9be78a0cafa268d0');
+    expect(SystemIds.SPACE_TYPE_ID).toBe('f4ce7263ed1456c5aafe8b74428ce812');
+    expect(SystemIds.PROPOSAL_TYPE_ID).toBe('1cb9d5bac73052a7bc731f2c3ff5a330');
+    expect(SystemIds.EOA_SPACE_TYPE_ID).toBe('09d28123178f5828b85a81979389c746');
+    expect(SystemIds.DAO_SPACE_TYPE_ID).toBe('afd76215db115cba81b9e7f77f865805');
+  });
+});

--- a/src/system-ids.test.ts
+++ b/src/system-ids.test.ts
@@ -3,10 +3,10 @@ import { SystemIds } from './system-ids.js';
 
 describe('SystemIds', () => {
   it('exports system type IDs', () => {
-    expect(SystemIds.SYSTEM_TYPE_ID).toBe('2ff7ea098b9e50bc9be78a0cafa268d0');
-    expect(SystemIds.SPACE_TYPE_ID).toBe('f4ce7263ed1456c5aafe8b74428ce812');
-    expect(SystemIds.PROPOSAL_TYPE_ID).toBe('1cb9d5bac73052a7bc731f2c3ff5a330');
-    expect(SystemIds.EOA_SPACE_TYPE_ID).toBe('09d28123178f5828b85a81979389c746');
-    expect(SystemIds.DAO_SPACE_TYPE_ID).toBe('afd76215db115cba81b9e7f77f865805');
+    expect(SystemIds.SYSTEM_TYPE).toBe('2ff7ea098b9e50bc9be78a0cafa268d0');
+    expect(SystemIds.SYSTEM_SPACE_TYPE).toBe('f4ce7263ed1456c5aafe8b74428ce812');
+    expect(SystemIds.PROPOSAL_TYPE).toBe('1cb9d5bac73052a7bc731f2c3ff5a330');
+    expect(SystemIds.EOA_SPACE_TYPE).toBe('09d28123178f5828b85a81979389c746');
+    expect(SystemIds.DAO_SPACE_TYPE).toBe('afd76215db115cba81b9e7f77f865805');
   });
 });


### PR DESCRIPTION
## Summary

System type IDs for System, Space, Proposal, EOA Space, and DAO Space are now available through the public `SystemIds` export. The new IDs use the SDK's canonical dashless `Id(...)` form and keep the existing legacy type constants untouched.

## Validation

- `pnpm test -- -t SystemIds` passed; due to the repo's Vitest argument handling, this ran the full non-e2e suite: 543 passed, 5 skipped.
- `pnpm build` passed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
